### PR TITLE
#132173349 load angular and other scripts over https

### DIFF
--- a/app/views/includes/foot.jade
+++ b/app/views/includes/foot.jade
@@ -10,9 +10,9 @@ script(type='text/javascript', src='/lib/underscore/underscore-min.js')
 script(type='text/javascript', src='/lib/bootstrap/js/bootstrap.js')
 
 //AngularJS
-script(type='text/javascript', src='http://code.angularjs.org/1.1.5/angular.js')
-script(type='text/javascript', src='http://code.angularjs.org/1.1.5/angular-resource.js')
-script(type='text/javascript', src='http://code.angularjs.org/1.1.5/angular-cookies.js')
+script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular.js')
+script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular-resource.js')
+script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular-cookies.js')
 
 //Angular UI
 script(type='text/javascript', src='/lib/angular-bootstrap/ui-bootstrap-tpls.js')

--- a/app/views/includes/head.jade
+++ b/app/views/includes/head.jade
@@ -12,7 +12,7 @@ head
   meta(name="viewport", content="initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=0")
 
   link(href='/img/icons/favicon.ico', rel='shortcut icon', type='image/x-icon')
-  link(href='http://fonts.googleapis.com/css?family=Lobster', rel='stylesheet', type='text/css')
+  link(href='https://fonts.googleapis.com/css?family=Lobster', rel='stylesheet', type='text/css')
 
   meta(property='fb:app_id', content='APP_ID')
   meta(property='og:title', content='#{appName} - #{title}')


### PR DESCRIPTION
#### What does this PR do?

Fix insecure script loading by using https instead of http
#### Description of Task to be completed?

Change the urls in jade templates to use https instead
#### How should this be manually tested?

go to [staging](https://ginsan-staging.herokuapp.com/)

view console the output. Angularjs should load successfully
